### PR TITLE
Fix: Add 'use client' directive to React Hook components

### DIFF
--- a/src/app/admin/settings/company/page.tsx
+++ b/src/app/admin/settings/company/page.tsx
@@ -1,3 +1,4 @@
+'use client'
 import SettingsShell from '@/components/admin/settings/SettingsShell'
 import dynamic from 'next/dynamic'
 import React, { useState, Suspense } from 'react'

--- a/src/app/admin/settings/financial/page.tsx
+++ b/src/app/admin/settings/financial/page.tsx
@@ -90,7 +90,7 @@ export default function FinancialSettingsPage() {
         {active==='currencies' && (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <Field label="Base" value={pending.currencies?.base ?? settings?.currencies?.base ?? 'USD'} onChange={(v)=>onChange('currencies','base', v)} />
-            <Field label="Enabled (comma)" value={(pending.currencies?.enabled ?? settings?.currencies?.enabled ?? ['USD']).join(', ')} onChange={(v)=>onChange('currencies','enabled', v.split(',').map(x=>x.trim()).filter(Boolean))} />
+            <Field label="Enabled (comma)" value={(pending.currencies?.enabled ?? settings?.currencies?.enabled ?? ['USD']).join(', ')} onChange={(v)=>onChange('currencies','enabled', String(v).split(',').map((x: string)=>x.trim()).filter(Boolean))} />
           </div>
         )}
 

--- a/src/components/admin/BookingSettingsPanel.tsx
+++ b/src/components/admin/BookingSettingsPanel.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React, { useEffect, useState } from 'react'
 import { Settings as SettingsIcon, CreditCard, Clock, Calendar, Bell, Users, Shield, Zap, Download, RefreshCw, Save, AlertTriangle, CheckCircle, Plug, Gauge, ListChecks, Upload } from 'lucide-react'
 import PermissionGate from '@/components/PermissionGate'


### PR DESCRIPTION
## Purpose
Fix Turbopack build errors by adding the required `'use client'` directive to components that use React Hooks. The user was experiencing build failures due to server-side components trying to use client-side React features like `useState` and `useEffect`.

## Code changes
- Added `'use client'` directive to `src/app/admin/settings/company/page.tsx` to enable `useState` hook usage
- Added `'use client'` directive to `src/components/admin/BookingSettingsPanel.tsx` to enable `useEffect` and `useState` hooks usage

These changes resolve the Turbopack build errors by properly marking components as client-side when they use React Hooks that require client-side execution.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 357`

🔗 [Edit in Builder.io](https://builder.io/app/projects/303c104b20bf4bc18deb1cbc480a33b7/orbit-space)

👀 [Preview Link](https://303c104b20bf4bc18deb1cbc480a33b7-orbit-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>303c104b20bf4bc18deb1cbc480a33b7</projectId>-->
<!--<branchName>orbit-space</branchName>-->